### PR TITLE
corrected the Deferred defn. for gdocs.js

### DIFF
--- a/backend.gdocs.js
+++ b/backend.gdocs.js
@@ -11,7 +11,7 @@ if (typeof module !== 'undefined' && module != null && typeof require !== 'undef
 (function(my) {
   my.__type__ = 'gdocs';
 
-  var Deferred = _.isUndefined(this.jQuery) ? _.Deferred : jQuery.Deferred;
+  var Deferred = (typeof jQuery !== "undefined" && jQuery.Deferred) || _.Deferred;
 
   // Fetch data from a Google Docs spreadsheet.
   //


### PR DESCRIPTION
The existing definition of `Deferred` is causing uncaught errors with _.isUndefined (when used in async mode with other frameworks).

Other recline backends (like csv etc., including the main recline.js) that did not have this problem are using this `typeof jQuery !== undefined` definition.

Correcting the code to be compatible with other backends and also eliminate the uncaught error with async exec.
