### PR TITLE
failure indication added for gdocs backend

### DIFF
--- a/backend.gdocs.js
+++ b/backend.gdocs.js
@@ -30,7 +30,7 @@ if (typeof module !== 'undefined' && module != null && typeof require !== 'undef
           titleDfd.resolve({
               spreadsheetTitle: d.feed.title.$t
           });
-      });
+      }) .fail(function(errObj) { titleDfd.reject(errObj); });
 
       return titleDfd.promise();
     }()).then(function (response) {
@@ -54,7 +54,7 @@ if (typeof module !== 'undefined' && module != null && typeof require !== 'undef
           useMemoryStore: true
         });
       });
-    });
+    }).fail(function(errObj) { dfd.reject(errObj); });
 
     return dfd.promise();
   };


### PR DESCRIPTION
Now failures are reported to the `dataset.fetch()` caller.
