### PR TITLE
taking care of empty cells

### DIFF
--- a/backend.gdocs.js
+++ b/backend.gdocs.js
@@ -96,7 +96,7 @@ if (typeof module !== 'undefined' && module != null && typeof require !== 'undef
 
       _.each(results.fields, function(col) {
         var _keyname = 'gsx$' + col;
-        var value = entry[_keyname].$t;
+        var value = (typeof entry[_keyname] === 'undefined' ? "": entry[_keyname].$t);
         var num;
  
         // TODO cover this part of code with test


### PR DESCRIPTION
The value conversion helper routine is throwing exceptions when cells are empty (as is usual case with many public domain spreadsheets).

This patch fixes it. 

One such example public domain spreadsheet for verification: https://docs.google.com/spreadsheet/ccc?key=0Ag0BxADNLZqgcFZOcnNoN0Vxd0Q3YTdOZ2hvRlpSQWc&usp=sharing#gid=0
